### PR TITLE
Add natural globe map view preference

### DIFF
--- a/circles/src/components/layout/profile-menu.tsx
+++ b/circles/src/components/layout/profile-menu.tsx
@@ -19,6 +19,7 @@ import { LOG_LEVEL_TRACE, logLevel } from "@/lib/data/constants";
 import { LuClipboardCheck, LuMail } from "react-icons/lu";
 import { listChatRoomsAction } from "../modules/chat/actions";
 import { getCircleDefaultPath } from "@/lib/utils/circle-routes";
+import { useIsMobile } from "@/components/utils/use-is-mobile";
 
 const ProfileMenuBar = () => {
     const router = useRouter();
@@ -30,6 +31,7 @@ const ProfileMenuBar = () => {
     const [notificationUnreadCount, setNotificationUnreadCount] = useAtom(notificationUnreadCountAtom);
     const [messageUnreadCount, setMessageUnreadCount] = useState(0);
     const pathname = usePathname();
+    const isMobile = useIsMobile();
 
     // Fixes hydration errors
     const [isMounted, setIsMounted] = useState(false);
@@ -123,6 +125,8 @@ const ProfileMenuBar = () => {
         return null;
     }
 
+    const isMobileExplore = isMobile && pathname === "/explore";
+
     return (
         <div className="flex items-center justify-center gap-1 overflow-visible">
             <>
@@ -144,41 +148,45 @@ const ProfileMenuBar = () => {
 
                     {authInfo.authStatus === "authenticated" && user && (
                         <>
-                            <Button
-                                variant="ghost"
-                                size="icon"
-                                className="relative h-9 w-9 rounded-full bg-[#f1f1f1] hover:bg-[#cecece]"
-                                onClick={() => router.push("/chat")}
-                            >
-                                <LuMail className="h-5 w-5" />
-                                {messageUnreadCount > 0 && (
-                                    <span className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-xs text-white">
-                                        {messageUnreadCount}
-                                    </span>
-                                )}
-                            </Button>
-                            <Button
-                                variant="ghost"
-                                size="icon"
-                                className="relative h-9 w-9 rounded-full bg-[#f1f1f1] hover:bg-[#cecece]"
-                                onClick={() => openUserToolbox("events")}
-                            >
-                                <LuClipboardCheck className="h-5 w-5" />
-                            </Button>
+                            {!isMobileExplore && (
+                                <>
+                                    <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        className="relative h-9 w-9 rounded-full bg-[#f1f1f1] hover:bg-[#cecece]"
+                                        onClick={() => router.push("/chat")}
+                                    >
+                                        <LuMail className="h-5 w-5" />
+                                        {messageUnreadCount > 0 && (
+                                            <span className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-xs text-white">
+                                                {messageUnreadCount}
+                                            </span>
+                                        )}
+                                    </Button>
+                                    <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        className="relative h-9 w-9 rounded-full bg-[#f1f1f1] hover:bg-[#cecece]"
+                                        onClick={() => openUserToolbox("events")}
+                                    >
+                                        <LuClipboardCheck className="h-5 w-5" />
+                                    </Button>
 
-                            <Button
-                                variant="ghost"
-                                size="icon"
-                                className="relative h-9 w-9 rounded-full bg-[#f1f1f1] hover:bg-[#cecece]"
-                                onClick={() => openUserToolbox("notifications")}
-                            >
-                                <Bell className="h-5 w-5" />
-                                {notificationUnreadCount > 0 && (
-                                    <span className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-xs text-white">
-                                        {notificationUnreadCount}
-                                    </span>
-                                )}
-                            </Button>
+                                    <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        className="relative h-9 w-9 rounded-full bg-[#f1f1f1] hover:bg-[#cecece]"
+                                        onClick={() => openUserToolbox("notifications")}
+                                    >
+                                        <Bell className="h-5 w-5" />
+                                        {notificationUnreadCount > 0 && (
+                                            <span className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-xs text-white">
+                                                {notificationUnreadCount}
+                                            </span>
+                                        )}
+                                    </Button>
+                                </>
+                            )}
 
                             <Button
                                 className="relative h-auto w-auto rounded-full p-0"

--- a/circles/src/components/map/map.tsx
+++ b/circles/src/components/map/map.tsx
@@ -3,6 +3,7 @@
 import React, { useCallback } from "react";
 import { useEffect, useRef, useState } from "react";
 import { AiOutlineRead } from "react-icons/ai";
+import { HiOutlineCheck, HiOutlineChevronDown } from "react-icons/hi";
 import { LiaGlobeAfricaSolid } from "react-icons/lia";
 import { sidePanelWidth } from "../../app/constants";
 import useWindowDimensions from "@/components/utils/use-window-dimensions";
@@ -74,6 +75,35 @@ const getMarkerInitials = (content: Content): string => {
         return words[0].slice(0, 2).toUpperCase();
     }
     return `${words[0][0] ?? ""}${words[words.length - 1][0] ?? ""}`.toUpperCase();
+};
+
+type MapStylePreference = "natural" | "classic";
+
+const MAP_STYLE_STORAGE_KEY = "kamooni.mapStylePreference";
+
+const parseMapStylePreference = (value: string | null | undefined): MapStylePreference =>
+    value === "classic" ? "classic" : "natural";
+
+const MAP_STYLES: Record<MapStylePreference, { label: string; url: string; hiddenLayers: string[] }> = {
+    natural: {
+        label: "Natural globe",
+        url: "mapbox://styles/mapbox/satellite-streets-v12",
+        hiddenLayers: [
+            "country-label",
+            "state-label",
+            "settlement-major-label",
+            "settlement-minor-label",
+            "settlement-subdivision-label",
+            "admin-0-boundary",
+            "admin-0-boundary-bg",
+            "admin-1-boundary",
+        ],
+    },
+    classic: {
+        label: "Classic map",
+        url: "mapbox://styles/mapbox/streets-v12",
+        hiddenLayers: [],
+    },
 };
 
 const getMarkerImageUrl = (content: Content): string | undefined => {
@@ -295,12 +325,14 @@ const createMarkerElement = (
 
 const MapBox = ({
     mapboxKey,
+    mapStylePreference,
     panelMode,
     windowWidth,
     windowHeight,
     feedPanelDocked,
 }: {
     mapboxKey: string;
+    mapStylePreference: MapStylePreference;
     panelMode?: string;
     windowWidth: number;
     windowHeight: number;
@@ -328,6 +360,10 @@ const MapBox = ({
     const popupRef = useRef<HTMLDivElement | null>(null);
     const popupContentRef = useRef<Content | null>(null);
     const popupCloseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const mapStylePreferenceRef = useRef<MapStylePreference>(mapStylePreference);
+    const appliedMapStyleRef = useRef<MapStylePreference>(mapStylePreference);
+
+    mapStylePreferenceRef.current = mapStylePreference;
 
     useEffect(() => {
         if (logLevel >= LOG_LEVEL_TRACE) {
@@ -512,14 +548,50 @@ const MapBox = ({
 
         map.current = new mapboxgl.Map({
             container: mapContainer.current,
-            style: "mapbox://styles/mapbox/streets-v12",
+            style: MAP_STYLES[appliedMapStyleRef.current].url,
+            projection: "globe",
             center: [lng, lat],
             zoom: zoom,
             //maxZoom: 12, // Limit maximum zoom to city level
         });
 
+        map.current.on("style.load", () => {
+            const currentMap = map.current;
+            if (!currentMap) {
+                return;
+            }
+
+            try {
+                currentMap.setProjection("globe");
+            } catch {
+                // Ignore projection support differences across style lifecycle states.
+            }
+
+            const styleConfig = MAP_STYLES[mapStylePreferenceRef.current];
+            if (mapStylePreferenceRef.current === "natural") {
+                styleConfig.hiddenLayers.forEach((layerId) => {
+                    if (currentMap.getLayer(layerId)) {
+                        currentMap.setLayoutProperty(layerId, "visibility", "none");
+                    }
+                });
+            }
+        });
+
         map.current.on("render", syncMarkerPositions);
     }, [mapContainer, lat, lng, zoom, mapboxKey, displayedContent, syncMarkerPositions]);
+
+    useEffect(() => {
+        if (!map.current) {
+            return;
+        }
+
+        if (appliedMapStyleRef.current === mapStylePreference) {
+            return;
+        }
+
+        appliedMapStyleRef.current = mapStylePreference;
+        map.current.setStyle(MAP_STYLES[mapStylePreference].url);
+    }, [mapStylePreference]);
 
     // Ensure Mapbox resizes when container size changes (handles animations and window resize)
     useEffect(() => {
@@ -783,12 +855,48 @@ export function MapDisplay({ mapboxKey }: { mapboxKey: string }) {
     }, [windowWidth]);
 
     const widthTransition = isResizing ? "none" : "width 0.35s ease-in-out";
+    const [mapStylePreference, setMapStylePreference] = useState<MapStylePreference>("natural");
+    const [isMapStyleMenuOpen, setIsMapStyleMenuOpen] = useState(false);
+    const mapStyleMenuRef = useRef<HTMLDivElement | null>(null);
 
     useEffect(() => {
         if (mapboxKey) {
             setMapboxKey(mapboxKey);
         }
     }, [mapboxKey, setMapboxKey]);
+
+    useEffect(() => {
+        if (typeof window === "undefined") {
+            return;
+        }
+
+        setMapStylePreference(parseMapStylePreference(window.localStorage.getItem(MAP_STYLE_STORAGE_KEY)));
+    }, []);
+
+    useEffect(() => {
+        if (typeof window === "undefined") {
+            return;
+        }
+
+        window.localStorage.setItem(MAP_STYLE_STORAGE_KEY, mapStylePreference);
+    }, [mapStylePreference]);
+
+    useEffect(() => {
+        if (!isMapStyleMenuOpen) {
+            return;
+        }
+
+        const handlePointerDown = (event: MouseEvent) => {
+            if (!mapStyleMenuRef.current?.contains(event.target as Node)) {
+                setIsMapStyleMenuOpen(false);
+            }
+        };
+
+        document.addEventListener("mousedown", handlePointerDown);
+        return () => {
+            document.removeEventListener("mousedown", handlePointerDown);
+        };
+    }, [isMapStyleMenuOpen]);
 
     // Fixes hydration errors
     const [isMounted, setIsMounted] = useState(false);
@@ -822,11 +930,56 @@ export function MapDisplay({ mapboxKey }: { mapboxKey: string }) {
                     >
                         <MapBox
                             mapboxKey={mapboxKey}
+                            mapStylePreference={mapStylePreference}
                             panelMode={panelMode}
                             windowWidth={windowWidth}
                             windowHeight={windowHeight}
                             feedPanelDocked={feedPanelDocked}
                         />
+                        <div
+                            ref={mapStyleMenuRef}
+                            className={`absolute z-40 ${isMobile ? "bottom-[46px] left-3" : "left-4 top-20"}`}
+                        >
+                            <button
+                                type="button"
+                                aria-haspopup="menu"
+                                aria-expanded={isMapStyleMenuOpen}
+                                aria-label="Map style"
+                                className="flex items-center gap-2 rounded-full border border-white/30 bg-black/35 px-3 py-2 text-sm font-semibold text-white shadow-lg backdrop-blur-md transition hover:bg-black/45"
+                                onClick={() => setIsMapStyleMenuOpen((open) => !open)}
+                            >
+                                <LiaGlobeAfricaSolid size="18px" />
+                                <span>{isMobile ? "Map" : MAP_STYLES[mapStylePreference].label}</span>
+                                <HiOutlineChevronDown className="opacity-80" size="16px" />
+                            </button>
+                            {isMapStyleMenuOpen && (
+                                <div
+                                    role="menu"
+                                    className={`absolute min-w-[170px] rounded-2xl border border-white/20 bg-[#101418]/90 p-1.5 text-white shadow-2xl backdrop-blur-md ${
+                                        isMobile ? "bottom-full mb-2 mt-0" : "left-0"
+                                    }`}
+                                >
+                                    {(Object.entries(MAP_STYLES) as [MapStylePreference, (typeof MAP_STYLES)[MapStylePreference]][]).map(
+                                        ([value, config]) => (
+                                            <button
+                                                key={value}
+                                                type="button"
+                                                role="menuitemradio"
+                                                aria-checked={mapStylePreference === value}
+                                                className="flex w-full items-center justify-between rounded-xl px-3 py-2 text-left text-sm transition hover:bg-white/10"
+                                                onClick={() => {
+                                                    setMapStylePreference(value);
+                                                    setIsMapStyleMenuOpen(false);
+                                                }}
+                                            >
+                                                <span>{config.label}</span>
+                                                {mapStylePreference === value ? <HiOutlineCheck size="16px" /> : null}
+                                            </button>
+                                        ),
+                                    )}
+                                </div>
+                            )}
+                        </div>
                     </div>
                 </>
             )}

--- a/circles/src/components/modules/circles/map-explorer.tsx
+++ b/circles/src/components/modules/circles/map-explorer.tsx
@@ -945,6 +945,9 @@ export const MapExplorer: React.FC<MapExplorerProps> = ({ allDiscoverableCircles
 
     if (!isMounted) return null;
 
+    const mobileTopControlsLeft = 12;
+    const mobileTopControlsRight = 128;
+
     const advancedFiltersContent = (
         <div className="space-y-3">
             {activeAdvancedFilterCount > 0 && (
@@ -1044,9 +1047,9 @@ export const MapExplorer: React.FC<MapExplorerProps> = ({ allDiscoverableCircles
             <div
                 className={`absolute ${isMobile ? "flex-col" : "flex-row"} z-[30] flex gap-2`} // allow profile icons to sit above
                 style={{
-                    left: !isMobile && panelMode !== "none" ? 440 : 16,
-                    right: isMobile ? 16 : 280, // Reduced from 420 to 280 to give more space to pills
-                    top: 16,
+                    left: isMobile ? mobileTopControlsLeft : panelMode !== "none" ? 440 : 16,
+                    right: isMobile ? mobileTopControlsRight : 280, // Reserve space on mobile for avatar/action buttons.
+                    top: isMobile ? 12 : 16,
                 }}
             >
                 {/* View Mode Toggle removed: Explore mode only */}
@@ -1055,7 +1058,7 @@ export const MapExplorer: React.FC<MapExplorerProps> = ({ allDiscoverableCircles
                 {viewMode === "explore" && !(sidePanelContentVisible === "toolbox" && isMobile) && (
                     <div className="flex min-w-0 flex-1 flex-col gap-2">
                         <div className="flex w-full flex-col gap-2 md:flex-row md:items-center md:gap-4">
-                            <div className="flex w-full md:w-[23.5rem] md:max-w-[23.5rem] md:flex-none items-center rounded-full bg-white/95 p-1 pl-4 shadow-md ring-1 ring-black/5 backdrop-blur-sm">
+                            <div className="flex w-full max-w-[calc(100vw-140px)] md:w-[23.5rem] md:max-w-[23.5rem] md:flex-none items-center rounded-full bg-white/95 p-1 pl-4 shadow-md ring-1 ring-black/5 backdrop-blur-sm">
                                 <input
                                     type="text"
                                     placeholder="Search people, circles, and events"


### PR DESCRIPTION
## Summary
- Adds a Natural globe map view as the default Explore map style.
- Keeps Classic map as an alternative.
- Stores the selected map view in browser localStorage.
- Improves mobile Explore layout so search no longer overlaps the avatar/action area.
- Keeps the mobile Map control compact and close to the bottom toolbar.

## Notes
- Natural globe hides country/city labels and national/admin borders for a more organic map.
- Classic map keeps the existing production-style Mapbox streets view.
- This does not add database/account settings yet.

## Tested
- Desktop /explore: Natural and Classic switching works.
- Desktop: map menu stays open until selection/click outside.
- Mobile /explore: search no longer overlaps avatar/actions.
- Mobile: Map menu opens upward and both options work.
- Refresh preserves map preference.